### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#Mini Chatter
+# Mini Chatter
 
 Minimalistic real-time chat application (merely 100 lines of code) using only [Ruby](https://www.ruby-lang.org/en/), [Rack](http://rack.github.io/) and [Websocket-Rack](https://github.com/imanel/websocket-rack). Not for use, just as a basic concept. There is also an exact same application using [Faye](http://faye.jcoglan.com/) over [here](https://github.com/DamirSvrtan/mini-chatter-faye).
 
-#Screenshot:
+# Screenshot:
 ![alt text](http://oi60.tinypic.com/2n7mn15.jpg "Chatter index")
 
-#Usage:
+# Usage:
 
 ```ruby
 git clone git@github.com:DamirSvrtan/mini-chatter.git


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
